### PR TITLE
Fix CJK(Chinese, Japanese, Korean) PosAlign.right bug.

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -66,7 +66,7 @@ Future<void> main() async {
   // ticket.text(
   //   'hello ! 中文字 # world @ éphémère &',
   //   styles: PosStyles(codeTable: PosCodeTable.westEur),
-  //   containsChinese: true,
+  //   containsCjk: true,
   // );
 
   bytes += generator.feed(2);

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -33,8 +33,8 @@ const cFontB = '${esc}M\x01'; // Font B
 const cTurn90On = '${esc}V\x01'; // Turn 90° clockwise rotation mode on
 const cTurn90Off = '${esc}V\x00'; // Turn 90° clockwise rotation mode off
 const cCodeTable = '${esc}t'; // Select character code table [N]
-const cKanjiOn = '$fs&'; // Select Kanji character mode
-const cKanjiOff = '$fs.'; // Cancel Kanji character mode
+const cCjkOn = '$fs&'; // Select CJK(Chinese, Japanese, Korean) character mode
+const cCjkOff = '$fs.'; // Cancel CJK(Chinese, Japanese, Korean) character mode
 
 // Print Position
 const cAlignLeft = '${esc}a0'; // Left justification

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -390,7 +390,7 @@ class Generator {
 
   /// Cut the paper
   ///
-  /// [mode] is used to define the full or partial cut (if supported by the priner)
+  /// [mode] is used to define the full or partial cut (if supported by the printer)
   List<int> cut({PosCutMode mode = PosCutMode.full}) {
     List<int> bytes = [];
     bytes += emptyLines(5);
@@ -446,7 +446,7 @@ class Generator {
     return bytes;
   }
 
-  /// Reverse feed for [n] lines (if supported by the priner)
+  /// Reverse feed for [n] lines (if supported by the printer)
   List<int> reverseFeed(int n) {
     List<int> bytes = [];
     bytes += Uint8List.fromList(
@@ -542,16 +542,17 @@ class Generator {
         final List<bool> isLexemeChinese = list[1];
 
         // Print each lexeme using codetable OR kanji
+        int? colIndex = colInd;
         for (var j = 0; j < lexemes.length; ++j) {
           bytes += _text(
             _encode(lexemes[j], isKanji: isLexemeChinese[j]),
             styles: cols[i].styles,
-            colInd: colInd,
+            colInd: colIndex,
             colWidth: cols[i].width,
             isKanji: isLexemeChinese[j],
           );
           // Define the absolute position only once (we print one line only)
-          // colInd = null;
+          colIndex = null;
         }
       }
     }
@@ -566,7 +567,7 @@ class Generator {
 
   /// Print an image using (ESC *) command
   ///
-  /// [image] is an instanse of class from [Image library](https://pub.dev/packages/image)
+  /// [image] is an instance of class from [Image library](https://pub.dev/packages/image)
   List<int> image(Image imgSrc, {PosAlign align = PosAlign.center}) {
     List<int> bytes = [];
     // Image alignment
@@ -613,7 +614,7 @@ class Generator {
 
   /// Print an image using (GS v 0) obsolete command
   ///
-  /// [image] is an instanse of class from [Image library](https://pub.dev/packages/image)
+  /// [image] is an instance of class from [Image library](https://pub.dev/packages/image)
   List<int> imageRaster(
     Image image, {
     PosAlign align = PosAlign.center,
@@ -628,7 +629,7 @@ class Generator {
     final int widthPx = image.width;
     final int heightPx = image.height;
     final int widthBytes = (widthPx + 7) ~/ 8;
-    final List<int> resterizedData = _toRasterFormat(image);
+    final List<int> rasterizedData = _toRasterFormat(image);
 
     if (imageFn == PosImageFn.bitImageRaster) {
       // GS v 0
@@ -639,7 +640,7 @@ class Generator {
       header.add(densityByte); // m
       header.addAll(_intLowHigh(widthBytes, 2)); // xL xH
       header.addAll(_intLowHigh(heightPx, 2)); // yL yH
-      bytes += List.from(header)..addAll(resterizedData);
+      bytes += List.from(header)..addAll(rasterizedData);
     } else if (imageFn == PosImageFn.graphics) {
       // 'GS ( L' - FN_112 (Image data)
       final List<int> header1 = List.from(cRasterImg.codeUnits);
@@ -649,7 +650,7 @@ class Generator {
       header1.addAll([49]); // c=49
       header1.addAll(_intLowHigh(widthBytes, 2)); // xL xH
       header1.addAll(_intLowHigh(heightPx, 2)); // yL yH
-      bytes += List.from(header1)..addAll(resterizedData);
+      bytes += List.from(header1)..addAll(rasterizedData);
 
       // 'GS ( L' - FN_50 (Run print)
       final List<int> header2 = List.from(cRasterImg.codeUnits);

--- a/lib/src/pos_column.dart
+++ b/lib/src/pos_column.dart
@@ -11,20 +11,19 @@ import 'dart:typed_data' show Uint8List;
 import 'pos_styles.dart';
 
 /// Column contains text, styles and width (an integer in 1..12 range)
-/// [containsChinese] not used if the text passed as textEncoded
+/// [containsCjk] not used if the text passed as textEncoded
 class PosColumn {
   PosColumn({
     this.text = '',
     this.textEncoded,
-    this.containsChinese = false,
+    this.containsCjk = false,
     this.width = 2,
     this.styles = const PosStyles(),
   }) {
     if (width < 1 || width > 12) {
       throw Exception('Column width must be between 1..12');
     }
-    if (text != null &&
-        text.length > 0 &&
+    if (text.length > 0 &&
         textEncoded != null &&
         textEncoded!.length > 0) {
       throw Exception(
@@ -34,7 +33,7 @@ class PosColumn {
 
   String text;
   Uint8List? textEncoded;
-  bool containsChinese;
+  bool containsCjk;
   int width;
   PosStyles styles;
 }

--- a/lib/src/text_with_type.dart
+++ b/lib/src/text_with_type.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:gbk_codec/gbk_codec.dart';
+
+class TextWithType {
+  TextWithType.fromText({
+    required this.text,
+    this.isCjk = false,
+  }) {
+      if (text!.length == 0) {
+        throw Exception('text should be passed');
+      }
+      encodedBytes = _encodeText(text!, isCjk: isCjk);
+  }
+
+  TextWithType.fromEncoded({
+    required this.encodedBytes,
+    this.isCjk = false,
+  }) {
+    if (encodedBytes.length == 0) {
+      throw Exception('encodedBytes should be passed');
+    }
+  }
+
+  String? text;
+  bool isCjk;
+  late Uint8List encodedBytes;
+
+  Uint8List _encodeText(String text, {bool isCjk = false}) {
+    // replace some non-ascii characters
+    text = text
+        .replaceAll("’", "'")
+        .replaceAll("´", "'")
+        .replaceAll("»", '"')
+        .replaceAll(" ", ' ')
+        .replaceAll("•", '.');
+    if (!isCjk) {
+      return latin1.encode(text);
+    } else {
+      return Uint8List.fromList(gbk_bytes.encode(text));
+    }
+  }
+}


### PR DESCRIPTION
Please merge #62 first.

# Overview

The following code will be printed across two lines due to wrong alignment.
```
    bytes += ticket.row([
      PosColumn(
          text: 'R右R',
          width: 12,
          styles: PosStyles(align: PosAlign.right),
          containsCjk: true),
```

# Test

The receipt on the right is before the bug was fixed.
left is after the bug fixed.
![IMG_3421](https://user-images.githubusercontent.com/1361816/137612651-56404b76-5d44-42d0-a7cd-f12a53001ec5.jpg)

Tested with below code.
```
  Future<List<int>> debugCjk(PaperSize paper, CapabilityProfile profile) async {
    final Generator ticket = Generator(paper, profile);
    List<int> bytes = [];

    bytes += ticket.text(
      '漢字ひらがなカタカナ',
      styles: PosStyles(
        align: PosAlign.center,
        height: PosTextSize.size2,
        width: PosTextSize.size2,
      ),
      containsCjk: true,
    );

    bytes += ticket.text(
      'L左L',
      styles: PosStyles(align: PosAlign.left),
      containsCjk: true,
    );
    bytes += ticket.text(
      'C中央C',
      styles: PosStyles(align: PosAlign.center),
      containsCjk: true,
    );
    bytes += ticket.text(
      'R右R',
      styles: PosStyles(align: PosAlign.right),
      containsCjk: true,
    );

    bytes += ticket.row([
      PosColumn(
          text: 'L左L',
          width: 4,
          styles: PosStyles(align: PosAlign.left),
          containsCjk: true),
      PosColumn(
          text: 'L左L',
          width: 4,
          styles: PosStyles(align: PosAlign.left),
          containsCjk: true),
      PosColumn(
          text: 'L左L',
          width: 4,
          styles: PosStyles(align: PosAlign.left),
          containsCjk: true),
    ]);
    bytes += ticket.row([
      PosColumn(
          text: 'C中央C',
          width: 4,
          styles: PosStyles(align: PosAlign.center),
          containsCjk: true),
      PosColumn(
          text: 'C中央C',
          width: 4,
          styles: PosStyles(align: PosAlign.center),
          containsCjk: true),
      PosColumn(
          text: 'C中央C',
          width: 4,
          styles: PosStyles(align: PosAlign.center),
          containsCjk: true),
    ]);
    bytes += ticket.row([
      PosColumn(
          text: 'R右R',
          width: 4,
          styles: PosStyles(align: PosAlign.right),
          containsCjk: true),
      PosColumn(
          text: 'R右R',
          width: 4,
          styles: PosStyles(align: PosAlign.right),
          containsCjk: true),
      PosColumn(
          text: 'R右R',
          width: 4,
          styles: PosStyles(align: PosAlign.right),
          containsCjk: true),
    ]);

    bytes += ticket.row([
      PosColumn(
          text: 'left', width: 4, styles: PosStyles(align: PosAlign.left)),
      PosColumn(
          text: 'left', width: 4, styles: PosStyles(align: PosAlign.left)),
      PosColumn(
          text: 'left', width: 4, styles: PosStyles(align: PosAlign.left)),
    ]);
    bytes += ticket.row([
      PosColumn(
          text: 'center', width: 4, styles: PosStyles(align: PosAlign.center)),
      PosColumn(
          text: 'center', width: 4, styles: PosStyles(align: PosAlign.center)),
      PosColumn(
          text: 'center', width: 4, styles: PosStyles(align: PosAlign.center)),
    ]);
    bytes += ticket.row([
      PosColumn(
          text: 'right', width: 4, styles: PosStyles(align: PosAlign.right)),
      PosColumn(
          text: 'right', width: 4, styles: PosStyles(align: PosAlign.right)),
      PosColumn(
          text: 'right', width: 4, styles: PosStyles(align: PosAlign.right)),
    ]);

    ticket.feed(1);
    ticket.cut();
    return bytes;
  }

```